### PR TITLE
兼容unicode字符小程序端显示

### DIFF
--- a/src/components/wxParse/html2json.js
+++ b/src/components/wxParse/html2json.js
@@ -220,10 +220,17 @@ function html2json(html, bindName) {
         },
         chars: function (text) {
             //debug(text);
+            var newText = unescape(
+                text
+                  .replace(/&#x/g, '%u')
+                  .replace(/\\u/g, '%u')
+                  .replace(/;/g, '')
+                  .replace(/%uA0/g, '&nbsp;')
+              )
             var node = {
                 node: 'text',
-                text: text,
-                textArray:transEmojiStr(text)
+                text: newText,
+                textArray:transEmojiStr(newText)
             };
             
             if (bufArray.length === 0) {

--- a/src/components/wxParse/wxParse.wxml
+++ b/src/components/wxParse/wxParse.wxml
@@ -25,7 +25,9 @@
 <template name="WxEmojiView">
   <view class="WxEmojiView wxParse-inline" style="{{item.styleStr}}">
     <block wx:for="{{item.textArray}}" wx:key="">
-      <block class="{{item.text == '\\n' ? 'wxParse-hide':''}}" wx:if="{{item.node == 'text'}}">{{item.text}}</block>
+      <block class="{{item.text == '\\n' ? 'wxParse-hide':''}}" wx:if="{{item.node == 'text'}}">
+        <text decode="{{true}}">{{item.text}}</text>
+      </block>
       <block wx:elif="{{item.node == 'element'}}">
         <image class="wxEmoji" src="{{item.baseSrc}}{{item.text}}" />
       </block>


### PR DESCRIPTION
当富文本有unicode字符的时候，在小程序端无法正常显示内容。


如下图所示:
![image](https://user-images.githubusercontent.com/10667077/66550593-566b8280-eb78-11e9-84f7-175f7880f1af.png)

优化后效果:
![image](https://user-images.githubusercontent.com/10667077/66550680-7c912280-eb78-11e9-9e35-3b9c45ea9026.png)

优化后，同时兼容html的转义字符例如:&nbsp;